### PR TITLE
Changed show() in Projects to allow NAMESPACE/PROJECT_NAME format.

### DIFF
--- a/src/Models/Projects.coffee
+++ b/src/Models/Projects.coffee
@@ -15,7 +15,11 @@ class Projects extends BaseModel
 
   show: (projectId, fn = null) =>
     @debug "Projects::show()"
-    @get "projects/#{parseInt projectId}", (data) => fn data if fn
+    if projectId.indexOf("/") isnt -1
+      projectId = encodeURIComponent(projectId)
+    else
+      projectId = parseInt(projectId)
+    @get "projects/#{projectId}", (data) => fn data if fn
 
   create: (params = {}, fn = null) =>
     @debug "Projects::create()"


### PR DESCRIPTION
According to http://api.gitlab.org/projects.html, it should be possible
to fetch a Project either by numerical ID, or by NAMESPACE/PROJECT_NAME.
