### PR TITLE
Projects::all() now calls itself recursively.

### DIFF
--- a/lib/Models/Projects.js
+++ b/lib/Models/Projects.js
@@ -30,7 +30,6 @@
     };
 
     Projects.prototype.all = function(params, fn) {
-      var _this = this;
       if (params == null) {
         params = {};
       }
@@ -42,14 +41,31 @@
         params = {};
       }
       this.debug("Projects::all()");
+      if (params.page == null) {
+        params.page = 1;
+      }
       if (params.per_page == null) {
         params.per_page = 100;
       }
-      return this.get("projects", params, function(data) {
-        if (fn) {
-          return fn(data);
-        }
-      });
+      return (function() {
+        var cb, data,
+          _this = this;
+        data = [];
+        cb = function(retData) {
+          if (retData.length === 100) {
+            _this.debug("Recurse Projects::all()");
+            data = data.concat(retData);
+            params.page++;
+            return _this.all(params, cb);
+          } else {
+            data = data.concat(retData);
+            if (fn) {
+              return fn(data);
+            }
+          }
+        };
+        return this.get("projects/all", params, cb);
+      }).bind(this)();
     };
 
     Projects.prototype.show = function(projectId, fn) {

--- a/src/Models/Projects.coffee
+++ b/src/Models/Projects.coffee
@@ -10,8 +10,23 @@ class Projects extends BaseModel
       fn = params
       params = {}
     @debug "Projects::all()"
+    params.page ?= 1
     params.per_page ?= 100
-    @get "projects", params, (data) => fn data if fn
+
+    (->
+      data = []
+      cb = (retData) =>
+        if retData.length == 100
+          @debug "Recurse Projects::all()"
+          data = data.concat(retData)
+          params.page++
+          @all params, cb
+        else
+          data = data.concat(retData)
+          fn data if fn
+        
+      @get "projects/all", params, cb
+    ).bind(@)()
 
   show: (projectId, fn = null) =>
     @debug "Projects::show()"


### PR DESCRIPTION
GitLab doesn’t tell us how many results total in a result set, so if we
query projects/all, and it returns 100 records, there may be 101 total,
so we must query projects/all again until it returns fewer than 100.

@moul We're way outside my knowledge of CoffeeScript here, if
there is a better way of getting a closure with it's `this` scope
bound, let me know and I'll make a correction :)
