### PR TITLE
Change Repository.listTree to accept params, added showFile

### DIFF
--- a/lib/Models/ProjectRepository.js
+++ b/lib/Models/ProjectRepository.js
@@ -13,6 +13,7 @@
     function ProjectRepository() {
       this.updateFile = __bind(this.updateFile, this);
       this.createFile = __bind(this.createFile, this);
+      this.showFile = __bind(this.showFile, this);
       this.listTree = __bind(this.listTree, this);
       this.diffCommit = __bind(this.diffCommit, this);
       this.showCommit = __bind(this.showCommit, this);
@@ -102,17 +103,39 @@
       });
     };
 
-    ProjectRepository.prototype.listTree = function(projectId, fn) {
+    ProjectRepository.prototype.listTree = function(projectId, params, fn) {
       var _this = this;
+      if (params == null) {
+        params = {};
+      }
       if (fn == null) {
         fn = null;
       }
       this.debug("Projects::listTree()");
-      return this.get("projects/" + (parseInt(projectId)) + "/repository/tree", function(data) {
+      if ('function' === typeof params) {
+        fn = params;
+        params = {};
+      }
+      return this.get("projects/" + (parseInt(projectId)) + "/repository/tree", params, function(data) {
         if (fn) {
           return fn(data);
         }
       });
+    };
+
+    ProjectRepository.prototype.showFile = function(projectId, params, fn) {
+      var _this = this;
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Projects::showFile()", params);
+      if (params.file_path && params.ref) {
+        return this.post("projects/" + (parseInt(params.projectId)) + "/repository/files", params, function(data) {
+          if (fn) {
+            return fn(data);
+          }
+        });
+      }
     };
 
     ProjectRepository.prototype.createFile = function(params, fn) {

--- a/src/Models/ProjectRepository.coffee
+++ b/src/Models/ProjectRepository.coffee
@@ -34,11 +34,19 @@ class ProjectRepository extends BaseModel
     @get "projects/#{parseInt projectId}/repository/branches/#{parseInt sha}", (data) => fn data if fn
 
   # === Tree
-  listTree: (projectId, fn = null) =>
+  listTree: (projectId, params = {}, fn = null) =>
     @debug "Projects::listTree()"
-    @get "projects/#{parseInt projectId}/repository/tree", (data) => fn data if fn
+    if 'function' is typeof(params)
+      fn = params
+      params = {}
+    @get "projects/#{parseInt projectId}/repository/tree", params, (data) => fn data if fn
 
   # == Files
+  showFile: (projectId, params, fn = null) =>
+    @debug "Projects::showFile()", params
+    if params.file_path and params.ref
+      @post "projects/#{parseInt params.projectId}/repository/files", params, (data) => fn data if fn
+
   createFile: (params = {}, fn = null) =>
     @debug "Projects::createFile()", params
     @post "projects/#{parseInt params.projectId}/repository/files", params, (data) => fn data if fn


### PR DESCRIPTION
Generated with CoffeeScript 1.7.1 instead of 1.6.3, caused a lot of file changes. Feel free to pull the important files out into another commit. The key changes are in ProjectRepository.coffee/.js

``` coffeescript
# === Tree
  listTree: (projectId, params = {}, fn = null) =>
    @debug "Projects::listTree()"
    if 'function' is typeof(params)
      fn = params
      params = {}
    @get "projects/#{parseInt projectId}/repository/tree", params, (data) => fn data if fn

  # == Files
  showFile: (projectId, params, fn = null) =>
    @debug "Projects::showFile()", params
    if params.file_path and params.ref
      @post "projects/#{parseInt params.projectId}/repository/files", params, (data) => fn data if fn
```
