### PR TITLE
Fix issues.create() to use correct endpoint

### DIFF
--- a/src/Models/Issues.coffee
+++ b/src/Models/Issues.coffee
@@ -35,6 +35,7 @@ class Issues extends BaseModel
 
   create: (params = {}, fn = null) =>
     @debug "Issues::create()"
-    @post "issues", params, (data) -> fn data if fn
+    projectId = params.id
+    @post "projects/#{projectId}/issues", params, (data) -> fn data if fn
 
 module.exports = (client) -> new Issues client


### PR DESCRIPTION
The "/issues" endpoint is no longer supported for POST. See API documentation: 

https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/issues.md
