### PR TITLE
add params to listCommits

### DIFF
--- a/lib/Models/Projects.js
+++ b/lib/Models/Projects.js
@@ -161,7 +161,7 @@
         fn = null;
       }
       this.debug("Projects::listCommits()");
-      return this.get("projects/" + params.id + "/repository/commits", (function(_this) {
+      return this.get("projects/" + params.id + "/repository/commits", params, (function(_this) {
         return function(data) {
           if (fn) {
             return fn(data);

--- a/src/Models/Projects.coffee
+++ b/src/Models/Projects.coffee
@@ -59,7 +59,7 @@ class Projects extends BaseModel
 
   listCommits: (params={}, fn=null) =>
     @debug "Projects::listCommits()"
-    @get "projects/#{params.id}/repository/commits", (data) => fn data if fn
+    @get "projects/#{params.id}/repository/commits", params, (data) => fn data if fn
 
   listTags: (params={}, fn=null) =>
     @debug "Projects::listTags()"


### PR DESCRIPTION
To allow use of the "ref_name" parameter, _listCommits_ should pass the _parms_ object so that we're able to get commits from a specific branch/tag. 

e.g.

```
gitlab.projects.listCommits({id:1,ref_name:"v1.0"},function(commits){  });
```

From the spec:
https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/commits.md
