### PR TITLE
fix HttpMethod in ProjectRepository.showFile

### DIFF
--- a/lib/Models/ProjectRepository.js
+++ b/lib/Models/ProjectRepository.js
@@ -200,7 +200,7 @@
       }
       this.debug("Projects::showFile()", params);
       if (params.file_path && params.ref) {
-        return this.post("projects/" + (Utils.parseProjectId(params.projectId)) + "/repository/files", params, (function(_this) {
+        return this.get("projects/" + (Utils.parseProjectId(params.projectId)) + "/repository/files", params, (function(_this) {
           return function(data) {
             if (fn) {
               return fn(data);

--- a/src/Models/ProjectRepository.coffee
+++ b/src/Models/ProjectRepository.coffee
@@ -60,7 +60,7 @@ class ProjectRepository extends BaseModel
   showFile: (projectId, params, fn = null) =>
     @debug "Projects::showFile()", params
     if params.file_path and params.ref
-      @post "projects/#{Utils.parseProjectId params.projectId}/repository/files", params, (data) => fn data if fn
+      @get "projects/#{Utils.parseProjectId params.projectId}/repository/files", params, (data) => fn data if fn
 
   createFile: (params = {}, fn = null) =>
     @debug "Projects::createFile()", params


### PR DESCRIPTION
In ProjectRepository the showFile-Function tries to POST to the gitlab-Api. This is wrong, showing a File is done through a GET request.

this commit fixes that issue
