### PR TITLE
fix callback.length issue

### DIFF
--- a/lib/ApiBaseHTTP.js
+++ b/lib/ApiBaseHTTP.js
@@ -81,7 +81,7 @@
               return fn(ret);
             case 2:
               return fn(err, ret);
-            case 3:
+            default:
               return fn(err, response, ret);
           }
         };

--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -41,7 +41,7 @@ class module.exports.ApiBaseHTTP extends ApiBase
       switch arity
         when 1 then fn ret
         when 2 then fn err, ret
-        when 3 then fn err, response, ret
+        else fn err, response, ret
 
   get: (path, query={}, fn=null) =>
     if 'function' is typeof query


### PR DESCRIPTION
callback will not run if you write this:

```
gitlab.projects.show(123, function () {
     next();
});
```
