### PR TITLE
Update to slumber 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "debug": "*",
-    "slumber": "0.9.0"
+    "slumber": "0.10.1"
   },
   "devDependencies": {
     "coffee-script": ">=1.9.1",


### PR DESCRIPTION
This avoids a Regular Expression Denial of Service attack that can occur
on the minimatch npm module.

https://nodesecurity.io/advisories/118
