### PR TITLE
Additional API calls to fetch Merge Request changes and versions

### DIFF
--- a/lib/Models/ProjectMergeRequests.js
+++ b/lib/Models/ProjectMergeRequests.js
@@ -15,6 +15,9 @@
       this.comment = bind(this.comment, this);
       this.update = bind(this.update, this);
       this.add = bind(this.add, this);
+      this.version = bind(this.version, this);
+      this.versions = bind(this.versions, this);
+      this.changes = bind(this.changes, this);
       this.show = bind(this.show, this);
       this.list = bind(this.list, this);
       return ProjectMergeRequests.__super__.constructor.apply(this, arguments);
@@ -59,6 +62,42 @@
           }
         };
       })(this));
+    };
+
+    ProjectMergeRequests.prototype.changes = function(projectId, mergerequestId, fn) {
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Projects:changesMergeRequest()");
+      return this.get(("projects/" + (Utils.parseProjectId(projectId)) + "/merge_request/") + ((parseInt(mergerequestId)) + "/changes"), function(data) {
+        if (fn) {
+          return fn(data);
+        }
+      });
+    };
+
+    ProjectMergeRequests.prototype.versions = function(projectId, mergerequestId, fn) {
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Projects:getAllVersionsMergeRequest()");
+      return this.get(("projects/" + (Utils.parseProjectId(projectId)) + "/merge_requests/") + ((parseInt(mergerequestId)) + "/versions"), function(data) {
+        if (fn) {
+          return fn(data);
+        }
+      });
+    };
+
+    ProjectMergeRequests.prototype.version = function(projectId, mergerequestId, versionId, fn) {
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Projects:getVersionMergeRequest()");
+      return this.get(("projects/" + (Utils.parseProjectId(projectId)) + "/merge_requests/") + ((parseInt(mergerequestId)) + "/versions/" + (parseInt(versionId))), function(data) {
+        if (fn) {
+          return fn(data);
+        }
+      });
     };
 
     ProjectMergeRequests.prototype.add = function(projectId, sourceBranch, targetBranch, assigneeId, title, fn) {

--- a/src/Models/ProjectMergeRequests.coffee
+++ b/src/Models/ProjectMergeRequests.coffee
@@ -17,6 +17,22 @@ class ProjectMergeRequests extends BaseModel
     @debug "Projects::mergerequest()"
     @get "projects/#{Utils.parseProjectId projectId}/merge_request/#{parseInt mergerequestId}", (data) => fn data if fn
 
+  changes: (projectId, mergerequestId, fn = null) =>
+    @debug "Projects:changesMergeRequest()"
+    @get "projects/#{Utils.parseProjectId projectId}/merge_request/" +
+      "#{parseInt mergerequestId}/changes", (data) -> fn data if fn
+
+  versions: (projectId, mergerequestId, fn = null) =>
+    @debug "Projects:getAllVersionsMergeRequest()"
+    @get "projects/#{Utils.parseProjectId projectId}/merge_requests/" +
+      "#{parseInt mergerequestId}/versions", (data) -> fn data if fn
+
+  version: (projectId, mergerequestId, versionId, fn = null) =>
+    @debug "Projects:getVersionMergeRequest()"
+    @get "projects/#{Utils.parseProjectId projectId}/merge_requests/" +
+      "#{parseInt mergerequestId}/versions/#{parseInt versionId}",
+      (data) -> fn data if fn
+
   add: (projectId, sourceBranch, targetBranch, assigneeId, title, fn = null) =>
     @debug "Projects::addMergeRequest()"
     params =

--- a/tests/ProjectMergeRequests.test.coffee
+++ b/tests/ProjectMergeRequests.test.coffee
@@ -1,0 +1,73 @@
+chai = require 'chai'
+expect = chai.expect
+sinon = require 'sinon'
+sinonChai = require 'sinon-chai'
+
+chai.use sinonChai
+
+describe "ProjectMergeRequests", ->
+  gitlab = null
+  projects = null
+  mergeRequests = null
+
+  before ->
+    gitlab = (require '../')
+      url: 'test'
+      token: 'test'
+
+    projects = gitlab.projects
+    mergeRequests = projects.merge_requests
+
+  describe "changes()", ->
+    it "should use GET verb", ->
+      getStub = sinon.stub mergeRequests, "get"
+
+      mergeRequests.changes 1, 100
+
+      getStub.restore()
+      expect(getStub).to.have.been.called
+
+    it "should pass Numeric projectIDs, mergeRequestId and compile url", ->
+      getStub = sinon.stub mergeRequests, "get"
+
+      mergeRequests.changes 1, 100
+
+      getStub.restore()
+      url = "projects/1/merge_request/100/changes"
+      expect(getStub).to.have.been.calledWith url
+
+  describe "versions()", ->
+    it "should use GET verb", ->
+      getStub = sinon.stub mergeRequests, "get"
+
+      mergeRequests.versions 1, 100
+
+      getStub.restore()
+      expect(getStub).to.have.been.called
+
+    it "should pass Numeric projectIDs, mergeRequestId and compile url", ->
+      getStub = sinon.stub mergeRequests, "get"
+
+      mergeRequests.versions 1, 100
+
+      getStub.restore()
+      url = "projects/1/merge_requests/100/versions"
+      expect(getStub).to.have.been.calledWith url
+
+  describe "version()", ->
+    it "should use GET verb", ->
+      getStub = sinon.stub mergeRequests, "get"
+
+      mergeRequests.version 1, 100, 200
+
+      getStub.restore()
+      expect(getStub).to.have.been.called
+
+    it "should pass Numeric projectIDs, mergeRequestId, versionId", ->
+      getStub = sinon.stub mergeRequests, "get"
+
+      mergeRequests.version 1, 100, 200
+
+      getStub.restore()
+      url = "projects/1/merge_requests/100/versions/200"
+      expect(getStub).to.have.been.calledWith url

--- a/tests/ProjectMergeRequests.test.js
+++ b/tests/ProjectMergeRequests.test.js
@@ -1,0 +1,80 @@
+(function() {
+  var chai, expect, sinon, sinonChai;
+
+  chai = require('chai');
+
+  expect = chai.expect;
+
+  sinon = require('sinon');
+
+  sinonChai = require('sinon-chai');
+
+  chai.use(sinonChai);
+
+  describe("ProjectMergeRequests", function() {
+    var gitlab, mergeRequests, projects;
+    gitlab = null;
+    projects = null;
+    mergeRequests = null;
+    before(function() {
+      gitlab = (require('../'))({
+        url: 'test',
+        token: 'test'
+      });
+      projects = gitlab.projects;
+      return mergeRequests = projects.merge_requests;
+    });
+    describe("changes()", function() {
+      it("should use GET verb", function() {
+        var getStub;
+        getStub = sinon.stub(mergeRequests, "get");
+        mergeRequests.changes(1, 100);
+        getStub.restore();
+        return expect(getStub).to.have.been.called;
+      });
+      return it("should pass Numeric projectIDs, mergeRequestId and compile url", function() {
+        var getStub, url;
+        getStub = sinon.stub(mergeRequests, "get");
+        mergeRequests.changes(1, 100);
+        getStub.restore();
+        url = "projects/1/merge_request/100/changes";
+        return expect(getStub).to.have.been.calledWith(url);
+      });
+    });
+    describe("versions()", function() {
+      it("should use GET verb", function() {
+        var getStub;
+        getStub = sinon.stub(mergeRequests, "get");
+        mergeRequests.versions(1, 100);
+        getStub.restore();
+        return expect(getStub).to.have.been.called;
+      });
+      return it("should pass Numeric projectIDs, mergeRequestId and compile url", function() {
+        var getStub, url;
+        getStub = sinon.stub(mergeRequests, "get");
+        mergeRequests.versions(1, 100);
+        getStub.restore();
+        url = "projects/1/merge_requests/100/versions";
+        return expect(getStub).to.have.been.calledWith(url);
+      });
+    });
+    return describe("version()", function() {
+      it("should use GET verb", function() {
+        var getStub;
+        getStub = sinon.stub(mergeRequests, "get");
+        mergeRequests.version(1, 100, 200);
+        getStub.restore();
+        return expect(getStub).to.have.been.called;
+      });
+      return it("should pass Numeric projectIDs, mergeRequestId, versionId", function() {
+        var getStub, url;
+        getStub = sinon.stub(mergeRequests, "get");
+        mergeRequests.version(1, 100, 200);
+        getStub.restore();
+        url = "projects/1/merge_requests/100/versions/200";
+        return expect(getStub).to.have.been.calledWith(url);
+      });
+    });
+  });
+
+}).call(this);


### PR DESCRIPTION
Additional API calls to fetch Merge Request changes and versions
Related to #154 issue. 

* get all changes per merge request
* get list of versions for merge request
* get changes for merge request version 